### PR TITLE
Add/fix function headers and update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,42 +38,6 @@ func writeFrames(frames []*lepton3.Frame) error {
 
 ### Reading CPTV Files
 
-```go
-
-import (
-    "fmt"
-    "os"
-
-    "github.com/TheCacophonyProject/go-cptv"
-    "github.com/TheCacophonyProject/lepton3"
-)
+See [cptvtool](https://github.com/TheCacophonyProject/go-cptv/tree/master/cptvtool) for a read example.
 
 
-func readFrames() ([]*lepton3.Frame, error) {
-    f, err := os.Open("some.cptv")
-    if err != nil {
-        return nil, err
-    }
-    defer f.Close()
-
-    r, err := cptv.NewReader(f)
-    if err != nil {
-        return nil, err
-    }
-    fmt.Println("timestamp:", r.Timestamp())
-    fmt.Println("device:", r.DeviceName())
-
-    var out []*lepton3.Frame
-    for {
-        frame := new(lepton3.Frame)
-        err := r.ReadFrame(frame)
-        if err != nil {
-            if err == io.EOF {
-                return out, nil
-            }
-            return err
-        }
-        out = append(out, frame)
-    }
-}
-```

--- a/builder.go
+++ b/builder.go
@@ -33,6 +33,7 @@ type Builder struct {
 	w *gzip.Writer
 }
 
+// WriteHeader writes a CPTV header to the current Writer
 func (b *Builder) WriteHeader(f *FieldWriter) error {
 	_, err := b.w.Write(append(
 		[]byte(magic),
@@ -48,6 +49,7 @@ func (b *Builder) WriteHeader(f *FieldWriter) error {
 	return err
 }
 
+// WriteFrame writes a CPTV frame to the current Writer
 func (b *Builder) WriteFrame(f *FieldWriter, frameData []byte) error {
 	// Frame header
 	_, err := b.w.Write([]byte{frameSection, byte(f.fieldCount)})
@@ -66,6 +68,7 @@ func (b *Builder) WriteFrame(f *FieldWriter, frameData []byte) error {
 	return err
 }
 
+// Close closes the current Writer
 func (b *Builder) Close() error {
 	if err := b.w.Flush(); err != nil {
 		return err

--- a/fields.go
+++ b/fields.go
@@ -52,9 +52,10 @@ func readFieldsN(r nReader) (Fields, error) {
 	return f, nil
 }
 
-// field key -> field data
+// Fields maps from field key -> field data
 type Fields map[byte][]byte
 
+// Uint8 returns the field at 'key' as a uint8
 func (f Fields) Uint8(key byte) (uint8, error) {
 	buf, err := f.get(key, 1)
 	if err != nil {
@@ -63,6 +64,7 @@ func (f Fields) Uint8(key byte) (uint8, error) {
 	return uint8(buf[0]), nil
 }
 
+// Uint16 returns the field at 'key' as a uint16
 func (f Fields) Uint16(key byte) (uint16, error) {
 	buf, err := f.get(key, 2)
 	if err != nil {
@@ -71,6 +73,7 @@ func (f Fields) Uint16(key byte) (uint16, error) {
 	return binary.LittleEndian.Uint16(buf), nil
 }
 
+// Uint32 returns the field at 'key' as a uint32
 func (f Fields) Uint32(key byte) (uint32, error) {
 	buf, err := f.get(key, 4)
 	if err != nil {
@@ -79,6 +82,7 @@ func (f Fields) Uint32(key byte) (uint32, error) {
 	return binary.LittleEndian.Uint32(buf), nil
 }
 
+// Uint64 returns the field at 'key' as a uint64
 func (f Fields) Uint64(key byte) (uint64, error) {
 	buf, err := f.get(key, 8)
 	if err != nil {
@@ -87,6 +91,7 @@ func (f Fields) Uint64(key byte) (uint64, error) {
 	return binary.LittleEndian.Uint64(buf), nil
 }
 
+// Timestamp returns the field at 'key' as a time value
 func (f Fields) Timestamp(key byte) (time.Time, error) {
 	tRaw, err := f.Uint64(key)
 	if err != nil {
@@ -95,6 +100,7 @@ func (f Fields) Timestamp(key byte) (time.Time, error) {
 	return time.Unix(0, int64(tRaw*1000)), nil
 }
 
+// String returns the field at 'key' as a character string
 func (f Fields) String(key byte) (string, error) {
 	buf, ok := f[key]
 	if !ok {
@@ -103,6 +109,8 @@ func (f Fields) String(key byte) (string, error) {
 	return string(buf), nil
 }
 
+// get returns the field at 'key' as a byte array after checking
+// its size vs expectedLen
 func (f Fields) get(key byte, expectedLen int) ([]byte, error) {
 	buf, ok := f[key]
 	if !ok {
@@ -114,6 +122,7 @@ func (f Fields) get(key byte, expectedLen int) ([]byte, error) {
 	return buf, nil
 }
 
+// NewFieldWriter creates a new FieldWriter
 func NewFieldWriter() *FieldWriter {
 	return &FieldWriter{
 		data: make([]byte, 0, 128),
@@ -126,11 +135,13 @@ type FieldWriter struct {
 	fieldCount uint8
 }
 
+// Uint8 writes a uint8 field with key 'code' and value 'v'
 func (f *FieldWriter) Uint8(code byte, v uint8) {
 	f.data = append(f.data, byte(1), code, byte(v))
 	f.fieldCount++
 }
 
+// Uint16 writes a uint16 field with key 'code' and value 'v'
 func (f *FieldWriter) Uint16(code byte, v uint16) {
 	b := []byte{2, code, 0, 0}
 	binary.LittleEndian.PutUint16(b[2:], v)
@@ -138,6 +149,7 @@ func (f *FieldWriter) Uint16(code byte, v uint16) {
 	f.fieldCount++
 }
 
+// Uint32 writes a uint32 field with key 'code' and value 'v'
 func (f *FieldWriter) Uint32(code byte, v uint32) {
 	b := []byte{4, code, 0, 0, 0, 0}
 	binary.LittleEndian.PutUint32(b[2:], v)
@@ -145,6 +157,7 @@ func (f *FieldWriter) Uint32(code byte, v uint32) {
 	f.fieldCount++
 }
 
+// Uint64 writes a uint64 field with key 'code' and value 'v'
 func (f *FieldWriter) Uint64(code byte, v uint64) {
 	b := []byte{8, code, 0, 0, 0, 0, 0, 0, 0, 0}
 	binary.LittleEndian.PutUint64(b[2:], v)
@@ -152,13 +165,15 @@ func (f *FieldWriter) Uint64(code byte, v uint64) {
 	f.fieldCount++
 }
 
+// Timestamp writes a time field with key 'code' and value 'v'
 func (f *FieldWriter) Timestamp(code byte, t time.Time) {
 	f.Uint64(code, uint64(t.UnixNano()/1000))
 }
 
+// String writes a character string field with key 'code' and value 'v'
 func (f *FieldWriter) String(code byte, v string) error {
 	if len(v) > 255 {
-		return fmt.Errorf("String length %d greater than 255.", len(v))
+		return fmt.Errorf("string length %d greater than 255", len(v))
 	}
 
 	byteSlice := []byte(v)

--- a/filereader.go
+++ b/filereader.go
@@ -46,7 +46,7 @@ type FileReader struct {
 	f  *os.File
 }
 
-// Name returns the name of the FileReader
+// Name returns the name of the file being read
 func (fr *FileReader) Name() string {
 	return fr.f.Name()
 }

--- a/filewriter.go
+++ b/filewriter.go
@@ -19,6 +19,8 @@ import (
 	"os"
 )
 
+// NewFileWriter creates file 'filename' and returns a new FileWriter
+// with underlying buffer (bufio) Writer
 func NewFileWriter(filename string) (*FileWriter, error) {
 	f, err := os.Create(filename)
 	if err != nil {
@@ -40,10 +42,12 @@ type FileWriter struct {
 	f  *os.File
 }
 
+// Name returns the name of the open File
 func (fw *FileWriter) Name() string {
 	return fw.f.Name()
 }
 
+// Close flushes the buffered writer and closes the open file
 func (fw *FileWriter) Close() {
 	fw.Writer.Close()
 	fw.bw.Flush()

--- a/parser.go
+++ b/parser.go
@@ -41,6 +41,7 @@ type Parser struct {
 	r nReader
 }
 
+// Header parses a CPTV file header from the open file.
 func (p *Parser) Header() (Fields, error) {
 	if magicRead, err := p.r.ReadN(4); err != nil {
 		return nil, err
@@ -59,6 +60,8 @@ func (p *Parser) Header() (Fields, error) {
 	return readFieldsN(p.r)
 }
 
+// Frame parses a CPTV frame section header from the open file and returns
+// a subreader that allows access to the frame bytes.
 func (p *Parser) Frame() (Fields, io.Reader, error) {
 	if err := p.checkByte("section", frameSection); err != nil {
 		return nil, nil, err
@@ -72,7 +75,7 @@ func (p *Parser) Frame() (Fields, io.Reader, error) {
 		return nil, nil, err
 	}
 
-	// Return a subreader which is only allows access to the bytes for
+	// Return a subreader which only allows access to the bytes for
 	// the frame.
 	frameReader := &io.LimitedReader{
 		R: p.r.Reader,
@@ -81,6 +84,8 @@ func (p *Parser) Frame() (Fields, io.Reader, error) {
 	return fields, frameReader, nil
 }
 
+// checkByte reads a byte from the file and checks it against an 'expected'
+// value. 'label' is used for the error report only
 func (p *Parser) checkByte(label string, expected byte) error {
 	actual, err := p.r.ReadByte()
 	if err != nil {

--- a/writer.go
+++ b/writer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/TheCacophonyProject/lepton3"
 )
 
+// NewWriter creates and returns a new Writer component
 func NewWriter(w io.Writer) *Writer {
 	return &Writer{
 		bldr: NewBuilder(w),
@@ -35,6 +36,7 @@ type Writer struct {
 	t0   time.Time
 }
 
+// WriteHeader writes a CPTV file header
 func (w *Writer) WriteHeader(deviceName string) error {
 	w.t0 = time.Now()
 	fields := NewFieldWriter()
@@ -54,6 +56,7 @@ func (w *Writer) WriteHeader(deviceName string) error {
 	return w.bldr.WriteHeader(fields)
 }
 
+// WriteFrame writes a CPTV frame
 func (w *Writer) WriteFrame(frame *lepton3.Frame) error {
 	dt := uint64(time.Since(w.t0))
 	bitWidth, compFrame := w.comp.Next(frame)
@@ -64,6 +67,7 @@ func (w *Writer) WriteFrame(frame *lepton3.Frame) error {
 	return w.bldr.WriteFrame(fields, compFrame)
 }
 
+// Close closes the CPTV file
 func (w *Writer) Close() error {
 	return w.bldr.Close()
 }


### PR DESCRIPTION
Header updates and one error string update per golint errors. It also complained about the constants in const.go, but those seem fine the way they are. Readme updated to point to cptvtool rather than having another code block to maintain.
