### PR TITLE
CPTV Spec updated to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@
 
 This package implements a Go package for generating and consuming
 Cacophony Project Thermal Video (CPTV) files. For more details on
-these files see the [specification](https://github.com/TheCacophonyProject/go-cptv/blob/master/SPEC.md).
+these files see the specifications:
 
+* v1: (https://github.com/TheCacophonyProject/go-cptv/blob/master/SPECv1.md)
+* v2: (https://github.com/TheCacophonyProject/go-cptv/blob/master/SPECv2.md) (implementation in progress)
 
 ## Example Usage
 
@@ -39,5 +41,3 @@ func writeFrames(frames []*lepton3.Frame) error {
 ### Reading CPTV Files
 
 See [cptvtool](https://github.com/TheCacophonyProject/go-cptv/tree/master/cptvtool) for a read example.
-
-

--- a/SPECv1.md
+++ b/SPECv1.md
@@ -42,7 +42,7 @@ A field is represented as follows:
 The data format always starts with:
 
 * 4 magic bytes: "CPTV"
-* 1 byte: version code (1 at this stage)
+* 1 byte: version code: 1
 
 ## Header
 

--- a/SPECv2.md
+++ b/SPECv2.md
@@ -1,0 +1,99 @@
+# Introduction
+
+This document described the data format used to encode thermal video
+recordings for the Cacophony Project. The format is designed to
+efficiently represent thermal video data in a lossless way, and allow
+for future extensibility.
+
+# Data representation
+
+The data format is binary (non-text). All numbers are represented in
+little-endian form as this is the byte ordering used on the computer
+platforms we use.
+
+# Compression
+
+The data format allows for compression of thermal video frames
+internally and is then also compressed again using standard gzip
+compression to obtain higher levels of compression. In order to read
+data the entire file/stream must be passed through a gzip decompressor
+first.
+
+# Data Format
+
+## Field Represention
+
+Parts of the data format include variable length sections of
+fields. To allow for the addition of extra fields in the future
+without breaking existing readers, each field includes its length and
+a identifying field code. Readers should skip over fields which they
+don't recognise.
+
+A field is represented as follows:
+
+| Name   | Length | Type  | Description
+| ------ | ------ | ----- |----------------------------------------------
+| Length | 1      | uint8 | Length of the field's data
+| Code   | 1      | char  | Character identifying
+| Data   | ?      | ?     | Length & content depends on Length & Code
+
+## Identification
+
+The data format always starts with:
+
+* 4 magic bytes: "CPTV"
+* 1 byte: version code: 2
+
+## Header
+
+A single header should come next. It starts with:
+* 1 byte indicating the header: "H"
+* 1 byte indicating the number of fields in the header.
+
+After these a number of fields will exist.
+
+### Compulsory Header Fields
+
+| Name          | Length   | Code  | Type    | Description
+| ------------  | ------   | ----- | ------- | ---------------------------------------------
+| Timestamp     | 8        | 'T'   | uint64  | Microseconds since 1970-01-01 UTC
+| X resolution  | 4        | 'X'   | uint32  | Frame X resolution (columns)
+| Y resolution  | 4        | 'Y'   | uint32  | Frame Y resolution (rows)
+| Compression   | 1        | 'C'   | uint8   | Compression scheme in use (0 = uncompressed)
+| Device name   | Variable | 'D'   | string  | Device name e.g. ("somewhere01")
+
+### Optional header fields
+
+| Name          | Length   | Code  | Type    | Description
+| ------------  | ------   | ----- | ------- | ---------------------------------------------
+| Motion config | Variable | 'M'   | string  | Motion detection configuration in YAML
+| Preview secs  | 1        | 'P'   | uint8   | Number of seconds of recording before motion event was detected
+
+## Frames
+
+One or more frames will follow the header. Each frame starts with:
+* 1 byte indicating a frame: "F"
+* 1 byte indicating the number of fields in the frame.
+
+### Compulsory Frame Fields
+
+The following frame fields must exist in every frame:
+
+| Name          | Length | Code  | Type      | Description
+| ----------    | ------ | ----- | --------- | ------------------------------------------------------------------
+| Time on       | 4      | 't'   | uint32    | Time in ms since the camera was powered on
+| Bit width     | 1      | 'w'   | uint8     | Bit width of the frame data
+| Frame size    | 4      | 'f'   | uint32    | Size of the frame data
+| Last FFC time | 4      | 'c'   | uint32    | Time of last Flat Field Correction (in ms since camera powered on)
+
+### Frame Data
+
+Following the frame fields (as indicated by the field count at the
+start of the frame) there will be a bytes of frame data. The number of
+bytes will match the "frame size" header (code 'f') in the frame's fields.
+
+Decoding the frame will involve use of the frame's bit width and the
+compression scheme indicated in the header. For compression scheme 0
+(no compression) read the frame data using the bit width
+provided. Remember that data is always represented using little-endian
+ordering.


### PR DESCRIPTION
Updated CPTV specification to include fields for storing the motion detection config, preview secs and FFC timestamps. Due to the repurposing of the unused and inaccurate timestamp field the version number has been bumped.

- Added "Motion config" (optional)
- Added "Preview secs" field (optional)
- Added "Time on" and "Last FFC time" frame fields.

Repurposing the 't' frame field is a bit icky but it really wasn't
used and was inaccurate. Bumped to version 2 anyway to cover this.