### PR TITLE
add background frame to go-cptv

### DIFF
--- a/compatability_test.go
+++ b/compatability_test.go
@@ -31,6 +31,7 @@ func TestReadV1File(t *testing.T) {
 	require.Equal(t, 1, r.Version())
 	assert.Equal(t, "livingsprings03", r.DeviceName())
 	assert.Equal(t, time.Date(2018, 9, 6, 9, 21, 25, 0, time.UTC), r.Timestamp().UTC().Truncate(time.Second))
+	assert.False(t, r.HasBackgroundFrame())
 
 	frame := r.Reader.EmptyFrame()
 	count := 0
@@ -44,6 +45,7 @@ func TestReadV1File(t *testing.T) {
 		// Unsupported fields in v1.
 		assert.Equal(t, time.Duration(0), frame.Status.TimeOn)
 		assert.Equal(t, time.Duration(0), frame.Status.LastFFCTime)
+		assert.False(t, frame.Status.BackgroundFrame)
 
 		count++
 	}
@@ -58,6 +60,7 @@ func TestReadV2File(t *testing.T) {
 	require.Equal(t, 2, r.Version())
 	assert.Equal(t, "Wallaby", r.DeviceName())
 	assert.Equal(t, time.Date(2020, 8, 17, 19, 46, 16, 0, time.UTC), r.Timestamp().UTC().Truncate(time.Second))
+	assert.False(t, r.HasBackgroundFrame())
 
 	frame := r.Reader.EmptyFrame()
 	count := 0
@@ -70,6 +73,7 @@ func TestReadV2File(t *testing.T) {
 
 		assert.Equal(t, float64(0), frame.Status.TempC)
 		assert.Equal(t, float64(0), frame.Status.LastFFCTempC)
+		assert.False(t, frame.Status.BackgroundFrame)
 
 		count++
 	}

--- a/compress_test.go
+++ b/compress_test.go
@@ -125,7 +125,6 @@ func makeTestFrame(c cptvframe.CameraSpec) *cptvframe.Frame {
 			out.Pix[y][x] = uint16(((y * x) % (maxVal - minVal)) + minVal)
 		}
 	}
-
 	return out
 }
 

--- a/const.go
+++ b/const.go
@@ -40,12 +40,12 @@ const (
 	Brand        byte = 'B'
 	Firmware     byte = 'V'
 	CameraSerial byte = 'N'
-
 	// Frame field keys
-	TimeOn       byte = 't'
-	BitWidth     byte = 'w'
-	FrameSize    byte = 'f'
-	LastFFCTime  byte = 'c'
-	TempC        byte = 'a'
-	LastFFCTempC byte = 'b'
+	TimeOn          byte = 't'
+	BitWidth        byte = 'w'
+	FrameSize       byte = 'f'
+	LastFFCTime     byte = 'c'
+	TempC           byte = 'a'
+	LastFFCTempC    byte = 'b'
+	BackgroundFrame byte = 'g'
 )

--- a/cptvframe/telemetry.go
+++ b/cptvframe/telemetry.go
@@ -7,11 +7,12 @@ package cptvframe
 import "time"
 
 type Telemetry struct {
-	TimeOn       time.Duration
-	FFCState     string
-	FrameCount   int
-	FrameMean    uint16
-	TempC        float64
-	LastFFCTempC float64
-	LastFFCTime  time.Duration
+	TimeOn          time.Duration
+	FFCState        string
+	FrameCount      int
+	FrameMean       uint16
+	TempC           float64
+	LastFFCTempC    float64
+	LastFFCTime     time.Duration
+	BackgroundFrame bool
 }

--- a/reader.go
+++ b/reader.go
@@ -184,6 +184,11 @@ func (r *Reader) Accuracy() float32 {
 	return pre
 }
 
+func (r *Reader) HasBackgroundFrame() bool {
+	back, _ := r.header.Uint8(BackgroundFrame)
+	return back != 0
+}
+
 // ReadFrame extracts and decompresses the next frame in a CPTV
 // recording. At the end of the recording an io.EOF error will be
 // returned.
@@ -212,6 +217,13 @@ func (r *Reader) ReadFrame(out *cptvframe.Frame) error {
 		lastFFC, err := fields.Float32(LastFFCTempC)
 		if err == nil {
 			out.Status.LastFFCTempC = float64(lastFFC)
+		}
+
+		backgroundFrame, err := fields.Uint8(BackgroundFrame)
+		if err == nil {
+			out.Status.BackgroundFrame = backgroundFrame != 0
+		} else {
+			out.Status.BackgroundFrame = false
 		}
 	}
 


### PR DESCRIPTION
This allows thermal-recorder to write the background frame into the cptv file, which will help when doing the tracking on a a clip